### PR TITLE
feat: add django-diagrams hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,3 +20,9 @@
   entry: (has_perm|@permission_required)\(["'][^\."']+["']\)
   language: pygrep
   types: [python]
+#  when calling this hook in a repo you must add args: [<path to local settings e.g. qrhub.settings.local>] in the repo .pre-commit-config.yaml file
+- id: create-django-diagrams
+  name: Create Django Diagrams
+  entry: bash generate_diagrams.sh
+  language: system
+  files: ^.*/migrations/.*\.py$

--- a/generate_diagrams.sh
+++ b/generate_diagrams.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-directory="./docs/model_diagrams/"
+DIRECTORY="./docs/model_diagrams/"
 
 # If the directory doesn't exist, create it
-mkdir -p $directory
+mkdir -p $DIRECTORY
 
 
 SETTINGS_MODULE="$1"
@@ -21,7 +21,7 @@ done
 FINAL_APP_NAMES=($(echo "${APP_NAMES[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
 
 for APP in "${FINAL_APP_NAMES[@]}"; do
-    python -m django_diagram -a $APP -o ./docs/model_diagrams/$APP.md -s $SETTINGS_MODULE
+    python -m django_diagram -a $APP -o $DIRECTORY/$APP.md -s $SETTINGS_MODULE
 done
 
-git add ./docs/model_diagrams/
+git add $DIRECTORY

--- a/generate_diagrams.sh
+++ b/generate_diagrams.sh
@@ -10,8 +10,6 @@ SETTINGS_MODULE="$1"
 
 shift
 
-declare -A unique_apps
-
 MIGRATIONS=$@
 
 declare -a APP_NAMES=()

--- a/generate_diagrams.sh
+++ b/generate_diagrams.sh
@@ -2,10 +2,8 @@
 
 directory="./docs/model_diagrams/"
 
-if [ ! -d "$directory" ]; then
-    # If the directory doesn't exist, create it
-    mkdir -p $directory
-fi
+# If the directory doesn't exist, create it
+mkdir -p $directory
 
 
 SETTINGS_MODULE="$1"

--- a/generate_diagrams.sh
+++ b/generate_diagrams.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+directory="./docs/model_diagrams/"
+
+if [ ! -d "$directory" ]; then
+    # If the directory doesn't exist, create it
+    mkdir -p $directory
+fi
+
+
+SETTINGS_MODULE="$1"
+
+shift
+
+declare -A unique_apps
+
+MIGRATIONS=$@
+
+declare -a APP_NAMES=()
+
+for migration in $MIGRATIONS; do
+    APP_NAMES+=("$(echo "$migration" | cut -d'/' -f1)")
+done
+
+FINAL_APP_NAMES=($(echo "${APP_NAMES[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+
+for APP in "${FINAL_APP_NAMES[@]}"; do
+    python -m django_diagram -a $APP -o ./docs/model_diagrams/$APP.md -s $SETTINGS_MODULE
+done
+
+git add ./docs/model_diagrams/

--- a/generate_diagrams.sh
+++ b/generate_diagrams.sh
@@ -5,23 +5,30 @@ DIRECTORY="./docs/model_diagrams/"
 # If the directory doesn't exist, create it
 mkdir -p $DIRECTORY
 
-
+# the settings module is the first argument
 SETTINGS_MODULE="$1"
 
+# remove the first argument passed to the script
 shift
 
+# the rest of the arguments are migration file names
 MIGRATIONS=$@
 
+# declare an array to hold the app names
 declare -a APP_NAMES=()
 
+# loop through the migrations and get the app names
 for migration in $MIGRATIONS; do
     APP_NAMES+=("$(echo "$migration" | cut -d'/' -f1)")
 done
 
+# declare an array and use it to get the unique app names
 FINAL_APP_NAMES=($(echo "${APP_NAMES[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
 
+# loop through the unique app names and generate the diagrams
 for APP in "${FINAL_APP_NAMES[@]}"; do
     python -m django_diagram -a $APP -o $DIRECTORY/$APP.md -s $SETTINGS_MODULE
 done
 
+# add the diagrams to git
 git add $DIRECTORY


### PR DESCRIPTION
This hook will add/update diagram files in the docs directory of a django app when there are migration files present in the commit. The aim is to give a model relationship reference for developers and product owners. This is not intended for end user consumption, it is just an internal reference. 