### PR TITLE
ci: bump actions/cache to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - id: cache-pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: venv
           key: pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements/test.txt') }}


### PR DESCRIPTION
Old versions of action/cache have been deprecated and shut down as of 1st Feb 2025.

actions/cache#1510